### PR TITLE
[FIX] Translation string escape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Section Order:
 ### Security
 -->
 
+### Fixed
+
+- Escaping translation strings to fix potential issues with French and Italian translations
+
 ### Changed
 
 - Set user agent according to MDN guidelines

--- a/sovtimer/locale/django.pot
+++ b/sovtimer/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: AA Sov Timer 2.2.3\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/aa-sov-timer/issues\n"
-"POT-Creation-Date: 2024-12-15 11:31+0100\n"
+"POT-Creation-Date: 2025-01-13 14:46+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -59,108 +59,108 @@ msgstr ""
 msgid "Sovereignty campaigns"
 msgstr ""
 
-#: sovtimer/templates/sovtimer/base.html:27
+#: sovtimer/templates/sovtimer/base.html:20
 msgctxt "Decimal separator"
 msgid "."
 msgstr ""
 
-#: sovtimer/templates/sovtimer/base.html:28
+#: sovtimer/templates/sovtimer/base.html:21
 msgctxt "Thousands separator"
 msgid ","
 msgstr ""
 
-#: sovtimer/templates/sovtimer/base.html:29
+#: sovtimer/templates/sovtimer/base.html:22
 msgid "No data available in this table"
 msgstr ""
 
-#: sovtimer/templates/sovtimer/base.html:30
+#: sovtimer/templates/sovtimer/base.html:23
 msgctxt "Keep _END_ as it is. It will be replaced by a number."
 msgid "Showing _END_ entries"
 msgstr ""
 
-#: sovtimer/templates/sovtimer/base.html:31
+#: sovtimer/templates/sovtimer/base.html:24
 msgctxt "Keep _MAX_ as it is. It will be replaced by a number."
 msgid "(filtered from _MAX_ total entries)"
 msgstr ""
 
-#: sovtimer/templates/sovtimer/base.html:32
+#: sovtimer/templates/sovtimer/base.html:25
 msgid "No records available"
 msgstr ""
 
-#: sovtimer/templates/sovtimer/base.html:35
+#: sovtimer/templates/sovtimer/base.html:26
 msgid "Loading …"
 msgstr ""
 
-#: sovtimer/templates/sovtimer/base.html:36
+#: sovtimer/templates/sovtimer/base.html:27
 msgid "Processing …"
 msgstr ""
 
-#: sovtimer/templates/sovtimer/base.html:37
+#: sovtimer/templates/sovtimer/base.html:28
 msgid "Nothing found, sorry …"
 msgstr ""
 
-#: sovtimer/templates/sovtimer/base.html:39
+#: sovtimer/templates/sovtimer/base.html:29
 msgid "Search …"
 msgstr ""
 
-#: sovtimer/templates/sovtimer/base.html:41
+#: sovtimer/templates/sovtimer/base.html:30
 msgid "First"
 msgstr ""
 
-#: sovtimer/templates/sovtimer/base.html:42
+#: sovtimer/templates/sovtimer/base.html:31
 msgid "Last"
 msgstr ""
 
-#: sovtimer/templates/sovtimer/base.html:43
+#: sovtimer/templates/sovtimer/base.html:32
 msgid "Next"
 msgstr ""
 
-#: sovtimer/templates/sovtimer/base.html:44
+#: sovtimer/templates/sovtimer/base.html:33
 msgid "Previous"
 msgstr ""
 
-#: sovtimer/templates/sovtimer/base.html:47
+#: sovtimer/templates/sovtimer/base.html:34
 msgid ": activate to sort column ascending"
 msgstr ""
 
-#: sovtimer/templates/sovtimer/base.html:48
+#: sovtimer/templates/sovtimer/base.html:35
 msgid ": activate to sort column descending"
 msgstr ""
 
-#: sovtimer/templates/sovtimer/dashboard.html:23
+#: sovtimer/templates/sovtimer/dashboard.html:15
 #: sovtimer/templates/sovtimer/partials/dashboard/table.html:27
 msgid "Type"
 msgstr ""
 
-#: sovtimer/templates/sovtimer/dashboard.html:24
+#: sovtimer/templates/sovtimer/dashboard.html:16
 #: sovtimer/templates/sovtimer/partials/dashboard/table.html:28
 msgid "System"
 msgstr ""
 
-#: sovtimer/templates/sovtimer/dashboard.html:25
+#: sovtimer/templates/sovtimer/dashboard.html:17
 #: sovtimer/templates/sovtimer/partials/dashboard/table.html:29
 msgid "Constellation"
 msgstr ""
 
-#: sovtimer/templates/sovtimer/dashboard.html:26
+#: sovtimer/templates/sovtimer/dashboard.html:18
 #: sovtimer/templates/sovtimer/partials/dashboard/table.html:30
 msgid "Region"
 msgstr ""
 
-#: sovtimer/templates/sovtimer/dashboard.html:27
+#: sovtimer/templates/sovtimer/dashboard.html:19
 #: sovtimer/templates/sovtimer/partials/dashboard/table.html:31
 msgid "Owner / Defender"
 msgstr ""
 
-#: sovtimer/templates/sovtimer/dashboard.html:28
+#: sovtimer/templates/sovtimer/dashboard.html:20
 msgid "Active campaign"
 msgstr ""
 
-#: sovtimer/templates/sovtimer/dashboard.html:30 sovtimer/views.py:161
+#: sovtimer/templates/sovtimer/dashboard.html:21 sovtimer/views.py:161
 msgid "Yes"
 msgstr ""
 
-#: sovtimer/templates/sovtimer/dashboard.html:31 sovtimer/views.py:159
+#: sovtimer/templates/sovtimer/dashboard.html:22 sovtimer/views.py:159
 msgid "No"
 msgstr ""
 

--- a/sovtimer/templates/sovtimer/base.html
+++ b/sovtimer/templates/sovtimer/base.html
@@ -17,6 +17,23 @@
         </div>
 
         <div class="aa-sovtimer-body">
+            {% translate "." context "Decimal separator" as decimalSeparator %}
+            {% translate "," context "Thousands separator" as thousandsSeparator %}
+            {% translate "No data available in this table" as emptyTable %}
+            {% translate "Showing _END_ entries" as info context "Keep _END_ as it is. It will be replaced by a number." %}
+            {% translate "(filtered from _MAX_ total entries)" as infoFiltered context "Keep _MAX_ as it is. It will be replaced by a number." %}
+            {% translate "No records available" as infoEmpty %}
+            {% translate "Loading …" as loadingRecords %}
+            {% translate "Processing …" as processing %}
+            {% translate "Nothing found, sorry …" as zeroRecords%}
+            {% translate "Search …" as searchPaceholder %}
+            {% translate "First" as paginateFirst %}
+            {% translate "Last" as paginateLast %}
+            {% translate "Next" as paginateNext %}
+            {% translate "Previous" as paginatePrevious %}
+            {% translate ": activate to sort column ascending" as ariaSortAscending %}
+            {% translate ": activate to sort column descending" as ariaSortDescending %}
+
             <script>
                 const sovtimerJsSettingsDefaults = {
                     datetimeFormat: 'YYYY-MMM-DD, HH:mm',
@@ -24,28 +41,28 @@
                     dataTables: {
                         paging: true,
                         translation: {
-                            decimal: '{% translate "." context "Decimal separator" %}',
-                            thousands: '{% translate "," context "Thousands separator" %}',
-                            emptyTable: '{% translate "No data available in this table" %}',
-                            info: '{% translate "Showing _END_ entries" context "Keep _END_ as it is. It will be replaced by a number." %}',
-                            infoFiltered: '{% translate "(filtered from _MAX_ total entries)" context "Keep _MAX_ as it is. It will be replaced by a number." %}',
-                            infoEmpty: '{% translate "No records available" %}',
+                            decimal: '{{ decimalSeparator|escapejs }}',
+                            thousands: '{{ thousandsSeparator|escapejs }}',
+                            emptyTable: '{{ emptyTable|escapejs }}',
+                            info: '{{ info|escapejs }}',
+                            infoFiltered: '{{ infoFiltered|escapejs }}',
+                            infoEmpty: '{{ infoEmpty|escapejs }}',
                             infoPostFix: '',
                             lengthMenu: '_MENU_',
-                            loadingRecords: '{% translate "Loading …" %}',
-                            processing: '{% translate "Processing …" %}',
-                            zeroRecords: '{% translate "Nothing found, sorry …" %}',
+                            loadingRecords: '{{ loadingRecords|escapejs }}',
+                            processing: '{{ processing|escapejs }}',
+                            zeroRecords: '{{ zeroRecords|escapejs }}',
                             search: '_INPUT_',
-                            searchPlaceholder: '{% translate "Search …" %}',
+                            searchPlaceholder: '{{ searchPaceholder|escapejs }}',
                             paginate: {
-                                first: '{% translate "First" %}',
-                                last: '{% translate "Last" %}',
-                                next: '{% translate "Next" %}',
-                                previous: '{% translate "Previous" %}'
+                                first: '{{ paginateFirst|escapejs }}',
+                                last: '{{ paginateLast|escapejs }}',
+                                next: '{{ paginateNext|escapejs }}',
+                                previous: '{{ paginatePrevious|escapejs }}'
                             },
                             aria: {
-                                sortAscending: '{% translate ": activate to sort column ascending" %}',
-                                sortDescending: '{% translate ": activate to sort column descending" %}'
+                                sortAscending: '{{ ariaSortAscending|escapejs }}',
+                                sortDescending: '{{ ariaSortDescending|escapejs }}'
                             }
                         }
                     },

--- a/sovtimer/templates/sovtimer/dashboard.html
+++ b/sovtimer/templates/sovtimer/dashboard.html
@@ -12,6 +12,15 @@
 {% endblock %}
 
 {% block extra_javascript %}
+    {% translate "Type" as dtFilterType %}
+    {% translate "System" as dtFilterSystem %}
+    {% translate "Constellation" as dtFilterConstellation %}
+    {% translate "Region" as dtFilterRegion %}
+    {% translate "Owner / Defender" as dtFilterOwner %}
+    {% translate "Active campaign" as dtFilterActiveCampaign %}
+    {% translate "Yes" as yes %}
+    {% translate "No" as no %}
+
     <script>
         const sovtimerJsSettingsOverride = {
             url: {
@@ -20,15 +29,15 @@
             dateformat: 'YYYY-MM-DD HH:mm:ss',
             translation: {
                 dtFilter: {
-                    type: '{% translate "Type" %}',
-                    system: '{% translate "System" %}',
-                    constellation: '{% translate "Constellation" %}',
-                    region: '{% translate "Region" %}',
-                    owner: '{% translate "Owner / Defender" %}',
-                    activeCampaign: '{% translate "Active campaign" %}',
+                    type: '{{ dtFilterType|escapejs }}',
+                    system: '{{ dtFilterSystem|escapejs }}',
+                    constellation: '{{ dtFilterConstellation|escapejs }}',
+                    region: '{{ dtFilterRegion|escapejs }}',
+                    owner: '{{ dtFilterOwner|escapejs }}',
+                    activeCampaign: '{{ dtFilterActiveCampaign|escapejs }}',
                 },
-                yes: '{% translate "Yes" %}',
-                no: '{% translate "No" %}',
+                yes: '{{ yes|escapejs }}',
+                no: '{{ no|escapejs }}',
             },
             upcomingTimerThreshold: 4 * 60 * 60 * 1000, // 4 hours in milliseconds
         };


### PR DESCRIPTION
## Description

### Fixed

- Escaping translation strings to fix potential issues with French and Italian translations

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
