### PR TITLE
[FIX] `TypeError: object of type 'NoneType' has no len()` in update task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ Section Order:
 - Simplify constant names
 - Make ajax call URL an internal URL
 
+### Fixed
+
+- `TypeError: object of type 'NoneType' has no len()` in update task
+
 ## [2.3.0] - 2025-02-02
 
 ### Fixed

--- a/sovtimer/tasks.py
+++ b/sovtimer/tasks.py
@@ -72,7 +72,7 @@ def update_sov_campaigns() -> None:
     campaigns_from_esi = Campaign.get_sov_campaigns_from_esi()
 
     logger.debug(
-        msg=f"Number of sovereignty campaigns from ESI: {len(campaigns_from_esi)}"
+        msg=f"Number of sovereignty campaigns from ESI: {len(campaigns_from_esi or [])}"
     )
 
     if campaigns_from_esi:


### PR DESCRIPTION
## Description

### Fixed

- `TypeError: object of type 'NoneType' has no len()` in update task

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
