### PR TITLE
[FIX] Delete last campaign when there are no more campaigns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ Section Order:
 ### Security
 -->
 
+### Fixed
+
+- The last campaign wasn't removed reliably when there were no more campaigns reported
+  by ESI
+
 ## [2.3.1] - 2025-02-26
 
 ### Changed


### PR DESCRIPTION
## Description

### Fixed

- The last campaign wasn't removed reliably when there were no more campaigns reported
  by ESI

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
