### PR TITLE
[RELEASE] v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Section Order:
 ### Security
 -->
 
+## [2.4.0] - 2025-06-03
+
 ### Removed
 
 - Cache breaker for static files. Doesn't work as expected with `django-sri`.

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ prepare-release: graph_models pot
 #			fi; \
 #		done; \
 #	fi;
-	echo "Updated version in $(TEXT_BOLD)$(package)/__init__.py$(TEXT_BOLD_END)"
+	@echo "Updated version in $(TEXT_BOLD)$(package)/__init__.py$(TEXT_BOLD_END)"
 
 # Help
 .PHONY: help

--- a/sovtimer/__init__.py
+++ b/sovtimer/__init__.py
@@ -5,5 +5,5 @@ App init
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "2.3.5"
+__version__ = "2.4.0"
 __title__ = _("Sovereignty Timers")

--- a/sovtimer/locale/django.pot
+++ b/sovtimer/locale/django.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: AA Sov Timer 2.3.5\n"
+"Project-Id-Version: AA Sov Timer 2.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/aa-sov-timer/issues\n"
-"POT-Creation-Date: 2025-05-06 00:14+0200\n"
+"POT-Creation-Date: 2025-06-03 13:33+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"


### PR DESCRIPTION
## [2.4.0] - 2025-06-03

### Removed

- Cache breaker for static files. Doesn't work as expected with `django-sri`.