### PR TITLE
[RELEASE] v2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Section Order:
 ### Security
 -->
 
+## [2.4.1] - 2025-06-13
+
 ### Changed
 
 - Task code refactored \

--- a/sovtimer/__init__.py
+++ b/sovtimer/__init__.py
@@ -5,5 +5,5 @@ App init
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "2.4.0"
+__version__ = "2.4.1"
 __title__ = _("Sovereignty Timers")

--- a/sovtimer/locale/django.pot
+++ b/sovtimer/locale/django.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: AA Sov Timer 2.4.0\n"
+"Project-Id-Version: AA Sov Timer 2.4.1\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/aa-sov-timer/issues\n"
-"POT-Creation-Date: 2025-06-12 18:28+0200\n"
+"POT-Creation-Date: 2025-06-13 00:06+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"


### PR DESCRIPTION
## [2.4.1] - 2025-06-13

### Changed

- Task code refactored \
  This also fixes an issue with the ADMs getting reset when a Sovhub was reinforced.
  Unfortunately, the ADM information are not available in the ESI data for
  reinforced Sovhubs, so the code had to be changed to not reset the ADMs
  when a Sovhub is reinforced. \
  This will not fix it for already registered campaigns, but for new ones.
- Management command for the initial data load refactored
- zKillboard icon properly loaded via Django static files
- Dotlan constellation links now generated using the `eveonline` app