### PR TITLE
[RELEASE] v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Section Order:
 ### Security
 -->
 
+## [2.6.0] - 2025-08-14
+
 ### Changed
 
 - Use AA framework JS functions

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Make sure you're in the virtual environment (venv) of your Alliance Auth install
 Then install the latest version:
 
 ```shell
-pip install aa-sov-timer==2.5.1
+pip install aa-sov-timer==2.6.0
 ```
 
 #### Step 2: Update Your AA Settings<a name="step-2-update-your-aa-settings"></a>
@@ -135,7 +135,7 @@ Now your system is updating the sovereignty campaigns every 30 seconds.
 Add the app to your `conf/requirements.txt`:
 
 ```text
-aa-sov-timer==2.5.1
+aa-sov-timer==2.6.0
 ```
 
 #### Step 2: Update Your AA Settings<a name="step-2-update-your-aa-settings-1"></a>
@@ -186,7 +186,7 @@ Then run the following commands from your AA project directory (the one that
 contains `manage.py`).
 
 ```shell
-pip install aa-sov-timer==2.5.1
+pip install aa-sov-timer==2.6.0
 
 python manage.py collectstatic
 python manage.py migrate
@@ -199,7 +199,7 @@ Finally, restart your AA supervisor service.
 To update your existing installation of AA Sovereignty Timer, all you need to do is to update the respective line in your `conf/requirements.txt` file to the latest version.
 
 ```text
-aa-sov-timer==2.5.1
+aa-sov-timer==2.6.0
 ```
 
 Now rebuild your containers and restart them:

--- a/sovtimer/__init__.py
+++ b/sovtimer/__init__.py
@@ -5,7 +5,7 @@ App init
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "2.5.1"
+__version__ = "2.6.0"
 __title__ = _("Sovereignty Timers")
 
 __package_name__ = "aa-sov-timer"


### PR DESCRIPTION
## [2.6.0] - 2025-08-14

### Changed

- Use AA framework JS functions
- Minimum requirements
  - Alliance Auth >= 4.9.0