### PR TITLE
[RELEASE] 3.0.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,20 @@ Section Order:
 ### Security
 -->
 
+## [3.0.0-alpha.2] - 2025-09-04
+
+> [!CAUTION]
+>
+> This is an ALPHA version, not intended for production use!
+> Please test it in a safe environment first and [report any issues you find](https://github.com/ppfeufer/aa-sov-timer/issues).
+>
+> This version is pulling in an ALPHA version of `django-esi` as well,
+> so please be aware that this might break at any time.
+
+### Fixed
+
+- Warning: Cannot reinitialise DataTable
+
 ## [3.0.0-alpha.1] - 2025-09-04
 
 > [!CAUTION]

--- a/sovtimer/__init__.py
+++ b/sovtimer/__init__.py
@@ -5,7 +5,7 @@ App init
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "3.0.0-alpha.1"
+__version__ = "3.0.0-alpha.2"
 __title__ = _("Sovereignty Timers")
 
 __esi_compatibility_date__ = "2025-08-26"


### PR DESCRIPTION
## [3.0.0-alpha.2] - 2025-09-04

> [!CAUTION]
>
> This is an ALPHA version, not intended for production use!
> Please test it in a safe environment first and [report any issues you find](https://github.com/ppfeufer/aa-sov-timer/issues).
>
> This version is pulling in an ALPHA version of `django-esi` as well,
> so please be aware that this might break at any time.

### Fixed

- Warning: Cannot reinitialise DataTable