### PR TITLE
[FIX] Class 'Iterable' does not define '__sub__'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ Section Order:
 
 <!-- Your changes go here -->
 
+### Fixed
+
+- Class 'Iterable' does not define '__sub__', so the '-' operator cannot be used on
+  its instances
+
 ## [4.1.0] - 2026-05-19
 
 ### Changed

--- a/sovtimer/locale/django.pot
+++ b/sovtimer/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: AA Sov Timer 4.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/aa-sov-timer/issues\n"
-"POT-Creation-Date: 2026-05-19 16:49+0200\n"
+"POT-Creation-Date: 2026-05-21 19:59+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -35,23 +35,23 @@ msgstr ""
 msgid "Alliances"
 msgstr ""
 
-#: sovtimer/models.py:160
+#: sovtimer/models.py:161
 msgid "Sovereignty structure"
 msgstr ""
 
-#: sovtimer/models.py:161
+#: sovtimer/models.py:162
 msgid "Sovereignty structures"
 msgstr ""
 
-#: sovtimer/models.py:241
+#: sovtimer/models.py:242
 msgid "Sov Hub defense"
 msgstr ""
 
-#: sovtimer/models.py:269
+#: sovtimer/models.py:270
 msgid "Sovereignty campaign"
 msgstr ""
 
-#: sovtimer/models.py:270
+#: sovtimer/models.py:271
 msgid "Sovereignty campaigns"
 msgstr ""
 

--- a/sovtimer/models.py
+++ b/sovtimer/models.py
@@ -84,7 +84,8 @@ class Alliance(models.Model):
         existing_alliance_ids = set(
             existing_alliances.values_list("alliance_id", flat=True)
         )
-        alliances_to_create = alliance_ids - existing_alliance_ids
+
+        alliances_to_create = set(alliance_ids) - existing_alliance_ids
 
         # Create a list of new Alliance instances to be created in bulk
         new_alliances = []


### PR DESCRIPTION
## Description

### Fixed

- Class 'Iterable' does not define '__sub__', so the '-' operator cannot be used on
  its instances

## Type of Change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
