### PR TITLE
[RELEASE] v5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ Section Order:
 
 <!-- Your changes go here -->
 
+## [5.0.0] - 2026-06-07
+
 > [!IMPORTANT]
 >
 > **This version needs Alliance Auth v5!**
@@ -1106,5 +1108,6 @@ And restart your supervisor.
 [4.0.3]: https://github.com/ppfeufer/aa-sov-timer/compare/v4.0.2...v4.0.3 "v4.0.3"
 [4.1.0]: https://github.com/ppfeufer/aa-sov-timer/compare/v4.0.3...v4.1.0 "v4.1.0"
 [4.2.0]: https://github.com/ppfeufer/aa-sov-timer/compare/v4.1.0...v4.2.0 "v4.2.0"
+[5.0.0]: https://github.com/ppfeufer/aa-sov-timer/compare/v4.2.0...v5.0.0 "v5.0.0"
 [alliance auth 3.0.0 release notes]: https://gitlab.com/allianceauth/allianceauth/-/tags/v3.0.0 "Alliance Auth 3.0.0 release notes"
-[in development]: https://github.com/ppfeufer/aa-sov-timer/compare/v4.2.0...HEAD "In Development"
+[in development]: https://github.com/ppfeufer/aa-sov-timer/compare/v5.0.0...HEAD "In Development"

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Make sure you're in the virtual environment (venv) of your Alliance Auth install
 Then install the latest version:
 
 ```shell
-pip install aa-sov-timer==4.2.0
+pip install aa-sov-timer==5.0.0
 ```
 
 #### Step 2: Update Your AA Settings<a name="step-2-update-your-aa-settings"></a>
@@ -168,7 +168,7 @@ Once you have completed all previous steps, restart your AA supervisor service t
 Add the app to your `conf/requirements.txt`:
 
 ```text
-aa-sov-timer==4.2.0
+aa-sov-timer==5.0.0
 ```
 
 #### Step 2: Update Your AA Settings<a name="step-2-update-your-aa-settings-1"></a>
@@ -265,7 +265,7 @@ Then run the following commands from your AA project directory (the one that
 contains `manage.py`).
 
 ```shell
-pip install aa-sov-timer==4.2.0
+pip install aa-sov-timer==5.0.0
 
 python manage.py collectstatic
 python manage.py migrate
@@ -278,7 +278,7 @@ Finally, restart your AA supervisor service.
 To update your existing installation of AA Sovereignty Timer, all you need to do is to update the respective line in your `conf/requirements.txt` file to the latest version.
 
 ```text
-aa-sov-timer==4.2.0
+aa-sov-timer==5.0.0
 ```
 
 Now rebuild your containers and restart them:

--- a/sovtimer/__init__.py
+++ b/sovtimer/__init__.py
@@ -5,7 +5,7 @@ App init
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "4.2.0"
+__version__ = "5.0.0"
 __title__ = "Sovereignty Timer"
 __title_translated__ = _("Sovereignty Timer")
 


### PR DESCRIPTION
## [5.0.0] - 2026-06-07

> [!IMPORTANT]
> 
> **This version needs Alliance Auth v5!**
> 
> Please make sure to update your Alliance Auth instance **before** you install this
> version, otherwise an update to Alliance Auth will be pulled in unsupervised.

> [!WARNING]
> 
> If you haven't updated to AA Sovereignty Timer v4 yet, please make sure to read the
> update instructions and update to at least v4.0.0 before updating to this version,
> otherwise, the app will not work properly.

### Removed

- Support for Alliance Auth v4
- Deprecated migrations