### PR TITLE
[CHANGE] Use `pk` instead of `id` when referring to the primary key

### DIFF
--- a/.github/workflows/automated-checks.yml
+++ b/.github/workflows/automated-checks.yml
@@ -3,7 +3,7 @@ name: Tests
 env:
   COVERAGE_DATABASE_VERSION: mariadb:10.11
   COVERAGE_PYTHON_VERSION: 3.12
-  NODE_VERSION: 24 # [LTS] End of Life: 30 Apr 2028 (https://endoflife.date/nodejs)
+  NODE_VERSION: 26 # [LTS] End of Life: 30 Apr 2029 (https://endoflife.date/nodejs)
   REDIS_VERSION: latest
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,4 +58,5 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           # The name of the file(s) to upload
           files: |
-            dist/*
+            dist/*.tar.gz
+            dist/*.whl

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@
 # Set the default language versions for the hooks
 default_language_version:
   python: python3  # Force all Python hooks to use Python 3
-  node: 24.14.0  # Force all Node hooks to use this specific Node version
+  node: 26.3.0  # Force all Node hooks to use this specific Node version
 
 # https://pre-commit.ci/
 ci:
@@ -68,7 +68,7 @@ repos:
         name: Check for large files
         description: Check for large files that were added to the repository.
         args:
-          - --maxkb=1000
+          - --maxkb=2048  # 2 MB
 
       - id: detect-private-key
         name: Detect private key
@@ -120,8 +120,10 @@ repos:
         name: End of file fixer
         description: Ensure that files end with a newline.
 
-  - repo: https://github.com/eslint/eslint
-    rev: 9089853a593d6c7c0f11367da08a829e0ddfe092  # frozen: v10.6.0
+#  - repo: https://github.com/eslint/eslint
+#    rev: 9089853a593d6c7c0f11367da08a829e0ddfe092  # frozen: v10.6.0
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: 8763fc929b6232999d541a3d8eb49965a6b71afb  # frozen: v10.6.0
     hooks:
       - id: eslint
         name: ESLint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Section Order:
 
 ### Changed
 
+- Use `pk` instead of `id` when referring to the primary key of a model instance, since `id` is not guaranteed to be the primary key in Django.
 - Migrated to Alliance Auth proxy models for `Permission`, `User` and `Group`
 
 ## [5.0.1] - 2026-07-07

--- a/sovtimer/models.py
+++ b/sovtimer/models.py
@@ -80,10 +80,8 @@ class Alliance(models.Model):
         :rtype: dict[int, Alliance]
         """
 
-        existing_alliances = cls.objects.filter(alliance_id__in=alliance_ids)
-        existing_alliance_ids = set(
-            existing_alliances.values_list("alliance_id", flat=True)
-        )
+        existing_alliances = cls.objects.filter(pk__in=alliance_ids)
+        existing_alliance_ids = set(existing_alliances.values_list("pk", flat=True))
 
         alliances_to_create = set(alliance_ids) - existing_alliance_ids
 
@@ -118,9 +116,9 @@ class Alliance(models.Model):
             created_alliances = cls.objects.bulk_create(new_alliances)
 
         # Combine existing and newly created alliances into a single dictionary
-        all_alliances = {
-            alliance.alliance_id: alliance for alliance in existing_alliances
-        } | {alliance.alliance_id: alliance for alliance in created_alliances}
+        all_alliances = {alliance.pk: alliance for alliance in existing_alliances} | {
+            alliance.pk: alliance for alliance in created_alliances
+        }
 
         return all_alliances
 

--- a/sovtimer/tasks.py
+++ b/sovtimer/tasks.py
@@ -216,7 +216,7 @@ def update_sov_structures(  # pylint: disable=too-many-locals
 
     # Fetch solar systems from the database
     solar_systems = {
-        ss.id: ss for ss in SolarSystem.objects.filter(id__in=solar_system_ids)
+        ss.id: ss for ss in SolarSystem.objects.filter(pk__in=solar_system_ids)
     }
 
     esi_structure_ids = set()  # Track structure IDs from ESI to avoid duplicates

--- a/sovtimer/tests/test_models.py
+++ b/sovtimer/tests/test_models.py
@@ -139,8 +139,8 @@ class TestAlliance(BaseTestCase):
         """
 
         mock_existing_alliances = [
-            Alliance(alliance_id=1, name="Alliance 1"),
-            Alliance(alliance_id=2, name="Alliance 2"),
+            Alliance(pk=1, name="Alliance 1"),
+            Alliance(pk=2, name="Alliance 2"),
         ]
         mock_qs = MagicMock()
         mock_qs.__iter__.return_value = iter(mock_existing_alliances)
@@ -154,7 +154,7 @@ class TestAlliance(BaseTestCase):
         self.assertEqual(len(result), 2)
         self.assertEqual(result[1].name, "Alliance 1")
         self.assertEqual(result[2].name, "Alliance 2")
-        mock_filter.assert_called_once_with(alliance_id__in={1, 2})
+        mock_filter.assert_called_once_with(pk__in={1, 2})
         mock_bulk_create.assert_not_called()
         mock_get_alliance.assert_not_called()
 
@@ -178,7 +178,7 @@ class TestAlliance(BaseTestCase):
         """
 
         mock_existing_alliances = [
-            Alliance(alliance_id=1, name="Alliance 1"),
+            Alliance(pk=1, name="Alliance 1"),
         ]
         mock_qs = MagicMock()
         mock_qs.__iter__.return_value = iter(mock_existing_alliances)
@@ -192,8 +192,8 @@ class TestAlliance(BaseTestCase):
         mock_get_alliance.side_effect = [a2, a3]
 
         mock_bulk_create.return_value = [
-            Alliance(alliance_id=2, name="Alliance 2"),
-            Alliance(alliance_id=3, name="Alliance 3"),
+            Alliance(pk=2, name="Alliance 2"),
+            Alliance(pk=3, name="Alliance 3"),
         ]
 
         result = Alliance.bulk_get_or_create_from_esi(
@@ -204,7 +204,7 @@ class TestAlliance(BaseTestCase):
         self.assertEqual(result[1].name, "Alliance 1")
         self.assertEqual(result[2].name, "Alliance 2")
         self.assertEqual(result[3].name, "Alliance 3")
-        mock_filter.assert_called_once_with(alliance_id__in={1, 2, 3})
+        mock_filter.assert_called_once_with(pk__in={1, 2, 3})
         mock_get_alliance.assert_any_call(alliance_id=2, force_refresh=False)
         mock_get_alliance.assert_any_call(alliance_id=3, force_refresh=False)
         mock_bulk_create.assert_called_once()
@@ -239,7 +239,7 @@ class TestAlliance(BaseTestCase):
         )
 
         self.assertEqual(len(result), 0)
-        mock_filter.assert_called_once_with(alliance_id__in={1})
+        mock_filter.assert_called_once_with(pk__in={1})
         mock_get_alliance.assert_called_once_with(alliance_id=1, force_refresh=False)
         mock_bulk_create.assert_not_called()
 

--- a/sovtimer/tests/test_tasks.py
+++ b/sovtimer/tests/test_tasks.py
@@ -144,7 +144,7 @@ class TestUpdateSovStructures(BaseTestCase):
         ]
 
         mock_bulk_get_or_create.return_value = {
-            2001: Alliance(alliance_id=2001, name="Alliance 2001")
+            2001: Alliance(pk=2001, name="Alliance 2001")
         }
         mock_solar_system_filter.return_value = [SolarSystem(id=3001)]
         mock_bulk_create.return_value = None
@@ -157,7 +157,7 @@ class TestUpdateSovStructures(BaseTestCase):
         mock_bulk_get_or_create.assert_called_once_with(
             alliance_ids={2001}, force_refresh=False
         )
-        mock_solar_system_filter.assert_called_once_with(id__in={3001})
+        mock_solar_system_filter.assert_called_once_with(pk__in={3001})
         mock_bulk_create.assert_called_once()
         created = mock_bulk_create.call_args[0][0]
         self.assertEqual(len(created), 1)

--- a/sovtimer/tests/test_views.py
+++ b/sovtimer/tests/test_views.py
@@ -147,10 +147,10 @@ class TestDashboardData(BaseTestCase):
 
         constellation = MagicMock()
         constellation.name = "Constellation A"
-        constellation.id = 7002
+        constellation.pk = 7002
         region = MagicMock()
         region.name = "Region A"
-        region.id = 7001
+        region.pk = 7001
         constellation.region = region
         solar_system.constellation = constellation
         structure.solar_system = solar_system
@@ -216,7 +216,7 @@ class TestDashboardData(BaseTestCase):
         constellation.name = "Constellation B"
         region = MagicMock()
         region.name = "Region B"
-        region.id = 7003
+        region.pk = 7003
         constellation.region = region
         solar_system.constellation = constellation
         structure.solar_system = solar_system
@@ -288,10 +288,10 @@ class TestDashboardData(BaseTestCase):
 
         constellation = MagicMock()
         constellation.name = "Constellation U"
-        constellation.id = 7004
+        constellation.pk = 7004
         region = MagicMock()
         region.name = "Region U"
-        region.id = 7005
+        region.pk = 7005
         constellation.region = region
         solar_system.constellation = constellation
         structure.solar_system = solar_system
@@ -354,7 +354,7 @@ class TestDashboardData(BaseTestCase):
         constellation.name = "Constellation X"
         region = MagicMock()
         region.name = "Region X"
-        region.id = 7006
+        region.pk = 7006
         constellation.region = region
         solar_system.constellation = constellation
         structure.solar_system = solar_system

--- a/sovtimer/views.py
+++ b/sovtimer/views.py
@@ -102,8 +102,8 @@ def dashboard_data(  # pylint: disable=too-many-statements too-many-locals
 
         # Defender
         defender_name = alliance.name
-        defender_url = dotlan_alliance_url(eve_obj=alliance.alliance_id)
-        defender_logo_url = alliance_logo_url(alliance_id=alliance.alliance_id, size=32)
+        defender_url = dotlan_alliance_url(eve_obj=alliance.pk)
+        defender_logo_url = alliance_logo_url(alliance_id=alliance.pk, size=32)
         defender_name_html = (
             f'<a href="{defender_url}" target="_blank" rel="noopener noreferer">'
             f'<img class="aa-sovtimer-entity-logo-left me-2" src="{defender_logo_url}" '
@@ -111,7 +111,7 @@ def dashboard_data(  # pylint: disable=too-many-statements too-many-locals
         )
 
         # Region / System / Constellation URLs and HTML (compute region_url once)
-        region_url = dotlan_region_url(eve_obj=region.id)
+        region_url = dotlan_region_url(eve_obj=region.pk)
         campaign_system_name = solar_system.name
         solar_system_url = f"{region_url}/{campaign_system_name}"
         solar_system_name_html = f'<a href="{solar_system_url}" target="_blank" rel="noopener noreferer">{campaign_system_name}</a>'
@@ -161,8 +161,7 @@ def dashboard_data(  # pylint: disable=too-many-statements too-many-locals
                 f'title="{title}" data-bs-tooltip="aa-sovtimer">{icon_name}</i>'
             )
 
-            constellation_id = constellation.id
-            zkb_href = f"https://zkillboard.com/constellation/{constellation_id}/"
+            zkb_href = f"https://zkillboard.com/constellation/{constellation.pk}/"
             zkb_icon = f'<img src="{static("sovtimer/images/zkillboard.png")}" alt="zKillboard">'
             constellation_killboard_link = (
                 f'<a href="{zkb_href}" target="_blank" rel="noopener noreferer" '


### PR DESCRIPTION
## Description

### Changed

- Use `pk` instead of `id` when referring to the primary key of a model instance, since `id` is not guaranteed to be the primary key in Django.

## Type of Change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
